### PR TITLE
Add instructions on how to install from the Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ The list of configuration locations in order of precedence:
 - $XDG_CONFIG_HOME/urlview/urlview
 - $HOME/.config/urlview/urlview
 - $HOME/.urlview.
+
+## Installation
+If you use [Homebrew](https://brew.sh/), you can install this program from the tap [erikw/homebrew-xdg-urlview](https://github.com/erikw/homebrew-xdg-urlview):
+```console
+$ brew install erikw/xdg-urlview/xdg-urlview
+```


### PR DESCRIPTION
As a formula for this program does not [qualify](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md) for the homebrew-core repo, I created a custom tap [erikw/homebrew-xdg-urlview](https://github.com/erikw/homebrew-xdg-urlview) just for this program. For the users, it works just as easily though with just issuing

```command
$ brew install erikw/xdg-urlview/xdg-urlview
```



Fixes #1
