### PR TITLE
Update Homebrew tap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The list of configuration locations in order of precedence:
 In general, follow the instructions in [INSTALL](INSTALL).
 
 ### Homebrew
-If you use [Homebrew](https://brew.sh/), you can install this program from the tap [erikw/homebrew-xdg-urlview](https://github.com/erikw/homebrew-xdg-urlview):
+If you use [Homebrew](https://brew.sh/), you can install this program from the tap [erikw/tap](https://github.com/erikw/homebrew-tap):
 ```console
-$ brew install erikw/xdg-urlview/xdg-urlview
+$ brew install erikw/tap/xdg-urlview
 ```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The list of configuration locations in order of precedence:
 - $HOME/.urlview.
 
 ## Installation
+### General
+In general, follow the instructions in [INSTALL](INSTALL).
+
+### Homebrew
 If you use [Homebrew](https://brew.sh/), you can install this program from the tap [erikw/homebrew-xdg-urlview](https://github.com/erikw/homebrew-xdg-urlview):
 ```console
 $ brew install erikw/xdg-urlview/xdg-urlview


### PR DESCRIPTION
I decided to rename my Homebrew tap repo from `erikw/homebrew-xdg-urlview` to [erikw/tap](https://github.com/erikw/homebrew-tap), so that I can reuse this for more formulas. This seems to be the naming convention I've seen from other taps around on GitHub.

This PR:
* Update install command for homebrew to `$ brew install erikw/tap/xdg-urlview`
  * I have run the publish workflow so that binaries are available under the new name and tried it out to install it as well.
* Add link to `INSTALL` file (forgot this in my first PR, did not stage this change :P)
